### PR TITLE
fix: VERCEL_URL 환경 변수로 인한 fetch 오류 수정

### DIFF
--- a/src/lib/api/getPostDetail.ts
+++ b/src/lib/api/getPostDetail.ts
@@ -10,18 +10,23 @@ export async function fetchPostDetail({
   category,
   slug,
 }: Props): Promise<Post> {
-  console.log(BASE_URL);
-  const res = await fetch(
-    `${BASE_URL}/api/posts/${encodeURIComponent(category)}/${encodeURIComponent(slug)}`,
-    {
-      cache: 'no-store',
+  try {
+    console.log(BASE_URL);
+    const res = await fetch(
+      `${BASE_URL}/api/posts/${encodeURIComponent(category)}/${encodeURIComponent(slug)}`,
+      {
+        cache: 'no-store',
+      }
+    );
+
+    console.log(res);
+
+    if (!res.ok) {
+      throw new Error('Failed to fetch post');
     }
-  );
-
-  console.log(res);
-
-  if (!res.ok) {
+    return res.json();
+  } catch (error) {
+    console.error(error);
     throw new Error('Failed to fetch post');
   }
-  return res.json();
 }

--- a/src/lib/api/getPostDetail.ts
+++ b/src/lib/api/getPostDetail.ts
@@ -10,6 +10,7 @@ export async function fetchPostDetail({
   category,
   slug,
 }: Props): Promise<Post> {
+  console.log(BASE_URL);
   const res = await fetch(
     `${BASE_URL}/api/posts/${encodeURIComponent(category)}/${encodeURIComponent(slug)}`,
     {

--- a/src/lib/api/getPostDetail.ts
+++ b/src/lib/api/getPostDetail.ts
@@ -16,6 +16,9 @@ export async function fetchPostDetail({
       cache: 'no-store',
     }
   );
+
+  console.log(res);
+
   if (!res.ok) {
     throw new Error('Failed to fetch post');
   }

--- a/src/lib/api/getPostDetail.ts
+++ b/src/lib/api/getPostDetail.ts
@@ -11,7 +11,6 @@ export async function fetchPostDetail({
   slug,
 }: Props): Promise<Post> {
   try {
-    console.log(BASE_URL);
     const res = await fetch(
       `${BASE_URL}/api/posts/${encodeURIComponent(category)}/${encodeURIComponent(slug)}`,
       {
@@ -19,11 +18,6 @@ export async function fetchPostDetail({
       }
     );
 
-    console.log(res);
-
-    if (!res.ok) {
-      throw new Error('Failed to fetch post');
-    }
     return res.json();
   } catch (error) {
     console.error(error);

--- a/src/lib/api/url.ts
+++ b/src/lib/api/url.ts
@@ -1,11 +1,13 @@
 function getBaseURL() {
-  // if (process.env.VERCEL_URL) {
-  //   return `https://${process.env.VERCEL_URL}`;
-  // }
+  /**
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
 
-  // if (process.env.CI) {
-  //   return 'http://127.0.0.1:3000';
-  // }
+  if (process.env.CI) {
+    return 'http://127.0.0.1:3000';
+  }
+   */
 
   if (process.env.NEXT_PUBLIC_BASE_URL) {
     return process.env.NEXT_PUBLIC_BASE_URL;

--- a/src/lib/api/url.ts
+++ b/src/lib/api/url.ts
@@ -1,7 +1,7 @@
 function getBaseURL() {
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
+  // if (process.env.VERCEL_URL) {
+  //   return `https://${process.env.VERCEL_URL}`;
+  // }
 
   // if (process.env.CI) {
   //   return 'http://127.0.0.1:3000';


### PR DESCRIPTION
## 확인 사항  
- `process.env.VERCEL_URL`을 사용했을 때, undefined 또는 잘못된 값이 반환되어 fetch 요청이 실패하는 문제 발생  
- GitHub Actions 및 Vercel 환경에서 `BASE_URL` 설정 방식 수정 

## 작업 내용  
- `process.env.VERCEL_URL` 관련 로직을 주석 처리하여 사용하지 않도록 변경  

## 주의 사항  
- `process.env.VERCEL_URL`이 필요할 경우, Vercel 환경에서 정확한 값이 반환되는지 검토 필요  
- 추후 `VERCEL_URL`을 다시 적용하려면, Vercel 배포 환경에서 확인 필요